### PR TITLE
fix: 🐛 adjust order logic for free course

### DIFF
--- a/src/controllers/orderController.ts
+++ b/src/controllers/orderController.ts
@@ -158,6 +158,7 @@ export async function previewOrder(req: AuthRequest, res: Response, next: NextFu
         course: {
           title: course.title,
           cover_url: course.coverUrl,
+          price: course.price,
         },
         user: {
           id: user.id,
@@ -291,7 +292,7 @@ export async function createOrder(req: AuthRequest, res: Response, next: NextFun
     let paidAtTime = undefined;
     if (isFreeCourse) {
       const now = new Date();
-      paidAtTime = new Date(now.setHours(now.getHours() - 8)); // 調整成 UTC 時間
+      paidAtTime = now.toLocaleString("en-US", { timeZone: "UTC" }); //new Date(now.setHours(now.getHours() - 8)); // 調整成 UTC 時間
     }
 
     const order = AppDataSource.getRepository(Order).create({
@@ -385,6 +386,7 @@ export async function getOrderDetail(req: AuthRequest, res: Response, next: Next
       course: {
         title: order.course.title,
         coverUrl: order.course.coverUrl,
+        price: order.course.price,
       },
       coupon: order.coupon
         ? {


### PR DESCRIPTION
remove console.log

# Pull Request 概述

API No.14 建立訂單 ：發現免費課程的邏輯有點bug

---

### 解決的問題 (如果適用)

免費課程建立訂單時，status直接設為paid，且填入paidAt資料

---

### 本次 PR 的主要變更

請列出本次 PR 中引入的主要變更點，可以使用列表的形式：

* orderController : function createOrder


---

### 詳細說明


---

### 測試計畫

請描述你為了驗證本次 PR 的變更所進行的測試，以及如何重現這些測試。

* 使用者購買免費課程

**測試結果:**

符合預期

---

### 相關文件 (如果適用)

[API 14 建立課程訂單](https://www.notion.so/POST-api-v1-orders-1cd6a2468518803fba98cac2ea5dfbe3?pvs=4)

---


### Checklist

在提交 PR 之前，請確保你已經完成以下檢查：

* [ ] 我已經閱讀並理解了 [貢獻指南](CONTRIBUTING.md 或其他相關文件)。
* [ ] 我的程式碼風格與專案的風格保持一致。
* [ ] 我已經為我的變更編寫了單元測試 (如果適用)。
* [ ] 所有的測試都已通過。
* [ ] 我已經更新了相關的文件 (如果適用)。
* [ ] 我的提交資訊清晰明瞭。

---

### 截圖 (如果適用)

如果你的變更涉及到 UI 方面的修改，請在此處附上截圖以便審閱。

---

**感謝你的貢獻!**