### PR TITLE
fix: 🐛 adjust order paidAt time zone

### DIFF
--- a/src/controllers/orderController.ts
+++ b/src/controllers/orderController.ts
@@ -292,7 +292,7 @@ export async function createOrder(req: AuthRequest, res: Response, next: NextFun
     let paidAtTime = undefined;
     if (isFreeCourse) {
       const now = new Date();
-      paidAtTime = now.toLocaleString("en-US", { timeZone: "UTC" }); //new Date(now.setHours(now.getHours() - 8)); // 調整成 UTC 時間
+      paidAtTime = now.toISOString();
     }
 
     const order = AppDataSource.getRepository(Order).create({
@@ -610,8 +610,7 @@ export async function paymentCallback(req: Request, res: Response, next: NextFun
     if (RtnCode === "1") {
       order.status = "paid";
       const paidTime = TradeDate ? new Date(TradeDate) : new Date();
-      // 調整成 UTC 時間 與其他欄位時間格式統一
-      order.paidAt = new Date(paidTime.setHours(paidTime.getHours() - 8));
+      order.paidAt = paidTime;
     } else {
       order.status = "failed";
     }


### PR DESCRIPTION

# Pull Request 概述

資料庫時區調整後，訂單付款時間（paidAt)可直接存入不需轉換

---

### 解決的問題 (如果適用)

Order資料表，paidAt 付款時間時區

---

### 本次 PR 的主要變更

請列出本次 PR 中引入的主要變更點，可以使用列表的形式：

* orderController.ts:
* function createOrder
* function paymentCallback


---

### 詳細說明

付款成功或是購買免費課程時，都會寫入paidAt時間

---




### Checklist

在提交 PR 之前，請確保你已經完成以下檢查：

* [ ] 我已經閱讀並理解了 [貢獻指南](CONTRIBUTING.md 或其他相關文件)。
* [ ] 我的程式碼風格與專案的風格保持一致。
* [ ] 我已經為我的變更編寫了單元測試 (如果適用)。
* [ ] 所有的測試都已通過。
* [ ] 我已經更新了相關的文件 (如果適用)。
* [ ] 我的提交資訊清晰明瞭。

---

### 截圖 (如果適用)

如果你的變更涉及到 UI 方面的修改，請在此處附上截圖以便審閱。

---

**感謝你的貢獻!**