### PR TITLE
延續 #67 修改小地方與文件

### DIFF
--- a/src/controllers/courseController.ts
+++ b/src/controllers/courseController.ts
@@ -130,6 +130,8 @@ export async function getCourseDetail(req: Request, res: Response, next: NextFun
   }
 }
 
+// API #21 Code Review Start
+
 /**
  * API #21 GET /api/v1/courses/:courseId/sections
  *
@@ -200,6 +202,10 @@ export async function getCourseSections(req: Request, res: Response, next: NextF
     next(error);
   }
 }
+
+// API #21 Code Review End
+
+// API #22 Code Review Start
 
 /**
  * API #22 GET /api/v1/courses/:courseId/progress
@@ -289,3 +295,5 @@ export async function getCourseProgress(req: AuthRequest, res: Response, next: N
     next(error);
   }
 }
+
+// API #22 Code Review End

--- a/src/controllers/courseController.ts
+++ b/src/controllers/courseController.ts
@@ -130,8 +130,6 @@ export async function getCourseDetail(req: Request, res: Response, next: NextFun
   }
 }
 
-// API #21 Code Review Start
-
 /**
  * API #21 GET /api/v1/courses/:courseId/sections
  *
@@ -202,10 +200,6 @@ export async function getCourseSections(req: Request, res: Response, next: NextF
     next(error);
   }
 }
-
-// API #21 Code Review End
-
-// API #22 Code Review Start
 
 /**
  * API #22 GET /api/v1/courses/:courseId/progress
@@ -296,10 +290,8 @@ export async function getCourseProgress(req: AuthRequest, res: Response, next: N
   }
 }
 
-// API #22 Code Review End
-
 /**
- * API #23 PATCH /api/v1/courses/:courseId/sections/:sectionId/complete
+ * API #25 PATCH /api/v1/courses/:courseId/sections/:sectionId/complete
  *
  * 📘 [API 文件 Notion 連結](https://www.notion.so/PATCH-api-v1-courses-courseId-sections-sectionId-complete-1d06a246851880bfb699fe79039e08a8?pvs=4)
  *

--- a/src/routes/courseRoutes.ts
+++ b/src/routes/courseRoutes.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { getCourses, getCourseDetail, getCourseSections, getCourseProgress } from "../controllers/courseController";
+import { getCourses, getCourseDetail, getCourseSections, getCourseProgress, markSectionComplete } from "../controllers/courseController";
 import { isAuth } from "../middleware/isAuth";
 import { isStudent } from "../middleware/isStudent";
 
@@ -9,5 +9,6 @@ router.get("/", getCourses);
 router.get("/:courseId", getCourseDetail);
 router.get("/:courseId/sections", isAuth, isStudent, getCourseSections);
 router.get("/:courseId/progress", isAuth, isStudent, getCourseProgress);
+router.patch("/:courseId/sections/:sectionId/complete", isAuth, isStudent, markSectionComplete);
 
 export default router;


### PR DESCRIPTION
# Pull Request 概述 延續 #67 修改小地方與文件

實作課程學習相關的三個 API：API 21 取得課程章節列表、API 22 取得課程學習進度、API 25 標記章節完成。這些 API 構成了完整的學生課程學習功能，包括章節瀏覽、進度追蹤和完成標記。

API 21
https://www.notion.so/GET-api-v1-courses-courseId-sections-1d06a246851880398989f3606961d628?pvs=4
API 22
https://www.notion.so/GET-api-v1-courses-courseId-progress-1d06a24685188007b5b6fac93880b048?pvs=4
API 25
https://www.notion.so/PATCH-api-v1-courses-courseId-sections-sectionId-complete-1d06a246851880bfb699fe79039e08a8?pvs=4

---

### 解決的問題 (如果適用)

實作學生端課程學習系統的核心功能，提供完整的學習進度管理機制。

---

### 本次 PR 的主要變更

* **API 21**: 新增 `getCourseSections` 函數 - 取得指定課程的所有章節列表
* **API 22**: 新增 `getCourseProgress` 函數 - 取得當前用戶在指定課程的學習進度
* **API 25**: 新增 `markSectionComplete` 函數 - 標記章節為已完成狀態

* 新增對應的 GET 和 PATCH 路由於 `src/routes/courseRoutes.ts`
* 實作完整的參數驗證、權限控制和錯誤處理機制
* 加入學生身份驗證，確保只有已登入的學生可以使用這些功能

---

### 詳細說明

**API 21 - GET `/api/v1/courses/:courseId/sections`**
- 取得指定課程的所有已發布章節列表
- 按照章節順序 (`order_index`) 排序
- 返回章節的基本資訊：ID、標題、順序、內容、影片 URL

**API 22 - GET `/api/v1/courses/:courseId/progress`**
- 計算用戶在指定課程的學習進度
- 統計總章節數和已完成章節數
- 計算完成百分比（保留兩位小數）
- 返回進度記錄 ID（如果存在）

**API 25 - PATCH `/api/v1/courses/:courseId/sections/:sectionId/complete`**
- 將指定章節標記為已完成
- 更新 `student_progress.is_completed` 為 `true`
- 要求必須先有學習進度記錄才能標記完成
- 支援重複標記（冪等性）

**共同特性：**
- 完整的 UUID 格式驗證
- 課程和章節存在性檢查
- 軟刪除和發布狀態驗證
- 統一的錯誤回應格式
- 完整的 JSDoc 註解和 API 文件連結

---

### 測試計畫

測試用 SQL
```
SELECT
  c.id            AS course_id,
  c.title         AS course_title,
  array_agg(s.title ORDER BY s.order_index) AS sections
FROM courses c
LEFT JOIN sections s
  ON s.course_id = c.id
GROUP BY c.id, c.title
ORDER BY c.title;

--  此 sql 可以查看課程底下有哪些章節 : )
```

**API 21 測試：**
* 測試有效課程 ID 返回章節列表
* 測試無效課程 ID 返回 404
* 驗證章節按順序排列
* 確認只返回已發布且未刪除的章節

**API 22 測試：**
* 測試有學習記錄的課程進度計算
* 測試無學習記錄的課程（進度為 0%）
* 驗證百分比計算準確性
* 測試部分完成和全部完成的情況

**API 25 測試：**
* 測試標記未完成章節為已完成
* 測試重複標記已完成章節
* 測試無進度記錄的情況（返回 404）
* 測試無效的課程或章節 ID

**整合測試：**
* 測試三個 API 的協作流程
* 驗證標記完成後進度正確更新

**測試結果:**
- ✅ 所有 API 正常運作
- ✅ 參數驗證和錯誤處理完整
- ✅ 權限控制正確實施
- ✅ 資料庫查詢效能良好
- ✅ 回應格式統一且符合規範

---

### 相關文件 (如果適用)

* 更新了 API 文件，新增三個端點的詳細說明
* 新增對應的 Notion 文件連結
* 更新了路由配置文件

---

### 其他說明

**設計考量：**
- API 25 採用保守策略，要求先有學習記錄才能標記完成，確保資料一致性
- 進度計算只考慮已發布且未刪除的章節，避免統計偏差
- 所有 API 都包含完整的業務邏輯驗證，確保資料完整性

**效能考量：**
- 使用 QueryBuilder 進行高效的資料庫查詢
- 適當的索引使用（基於外鍵關聯）
- 避免 N+1 查詢問題

---

### Checklist

* [x] 我已經閱讀並理解了貢獻指南
* [x] 我的程式碼風格與專案的風格保持一致
* [x] 我已經實作了完整的錯誤處理邏輯
* [x] 我已經測試了各種邊界情況和異常流程
* [x] 我已經更新了路由配置
* [x] 我的提交資訊清晰明瞭
* [x] 程式碼包含完整的 JSDoc 註解和 API 文件連結
* [x] 所有 API 都通過了手動測試驗證

---

### 截圖 (如果適用)

N/A - 此為後端 API 實作，無 UI 變更。

---

**感謝你的貢獻!**
