### PR TITLE
Fix/sections response

### DIFF
--- a/src/controllers/instructorSectionsController.ts
+++ b/src/controllers/instructorSectionsController.ts
@@ -66,7 +66,6 @@ export async function getCourseSectionsByInstructor(req: AuthRequest, res: Respo
       content: section.content,
       videoUrl: section.videoUrl,
       isPublished: section.isPublished,
-      order: section.orderIndex,
     }));
 
     res.status(200).json({
@@ -104,7 +103,7 @@ export async function createSectionByInstructor(req: AuthRequest, res: Response,
     return;
   }
 
-  const { title } = parsedBody.data;
+  const { title, content } = parsedBody.data;
 
   try {
     const courseRepo = AppDataSource.getRepository(Course);
@@ -134,6 +133,7 @@ export async function createSectionByInstructor(req: AuthRequest, res: Response,
 
     const newSection = sectionRepo.create({
       title,
+      content,
       orderIndex: nextOrderIndex,
       course,
       isPublished: false,
@@ -146,8 +146,9 @@ export async function createSectionByInstructor(req: AuthRequest, res: Response,
       data: {
         id: newSection.id,
         title: newSection.title,
-        courseId: course.id,
-        createdAt: newSection.createdAt.toISOString(),
+        content: newSection.content,
+        videoUrl: newSection.videoUrl,
+        isPublished: newSection.isPublished,
       },
     });
   } catch (err) {
@@ -214,6 +215,8 @@ export async function updateSection(req: AuthRequest, res: Response, next: NextF
         id: updated.id,
         title: updated.title,
         content: updated.content,
+        videoUrl: updated.videoUrl,
+        isPublished: updated.isPublished,
       },
     });
   } catch (err) {
@@ -355,6 +358,8 @@ export async function publishSection(req: AuthRequest, res: Response, next: Next
       data: {
         id: section.id,
         title: section.title,
+        content: section.content,
+        videoUrl: section.videoUrl,
         isPublished: section.isPublished,
       },
     });
@@ -480,7 +485,6 @@ export async function batchCreateSections(req: AuthRequest, res: Response, next:
         content: s.content,
         videoUrl: s.videoUrl,
         isPublished: s.isPublished,
-        order: s.orderIndex,
       })),
     });
   } catch (err) {

--- a/src/test/testInstructorSectionController/batchCreateSections.api.test.ts
+++ b/src/test/testInstructorSectionController/batchCreateSections.api.test.ts
@@ -66,7 +66,6 @@ describe("POST /api/v1/instructor/courses/:courseId/sections/batch", () => {
         content: "簡介",
         videoUrl: null,
         isPublished: false,
-        orderIndex: 4,
       },
       {
         id: "section-2",
@@ -74,7 +73,6 @@ describe("POST /api/v1/instructor/courses/:courseId/sections/batch", () => {
         content: "進階內容",
         videoUrl: null,
         isPublished: false,
-        orderIndex: 5,
       },
     ]);
 
@@ -84,7 +82,6 @@ describe("POST /api/v1/instructor/courses/:courseId/sections/batch", () => {
     expect(res.body.status).toBe("success");
     expect(res.body.data).toHaveLength(2);
     expect(res.body.data[0]).toHaveProperty("id");
-    expect(res.body.data[0].order).toBe(4);
   });
 
   it("🔐 缺少 JWT → 回傳 401", async () => {


### PR DESCRIPTION
# Pull Request 概述

根據這份[前端需求文件](https://www.notion.so/API-CRUD-2046a246851880d8ac60c3dfd70ee208?source=copy_link)
統一並優化講師章節相關 API 的回應格式，並完善章節創建功能。
更新以下AP文件內容
- [創建章節](https://www.notion.so/POST-api-v1-instructor-courses-courseId-sections-1d06a246851880e9b135cf4e521dfeec?source=copy_link)
- [更新章節](https://www.notion.so/PATCH-api-v1-instructor-sections-sectionId-1d06a246851880978816daf98305629b?source=copy_link)
- [發布/下架章節](https://www.notion.so/PATCH-api-v1-instructor-courses-id-publish-1f86a2468518804c9813f3738fbf14a2?source=copy_link)
- [取得章節列表](https://www.notion.so/GET-api-v1-instructor-courses-courseId-sections-1d06a24685188031bb7cdd6ea6c6113f?source=copy_link)
- [批量創建章節](https://www.notion.so/POST-api-v1-instructor-courses-courseId-sections-batch-2006a246851880e5a48cf08e533e4ba5?source=copy_link)

---

### 解決的問題

* 統一所有章節相關 API 的回應格式
* 完善章節創建 API 的功能，支援同時創建標題和內容

---

### 本次 PR 的主要變更

* 統一單個章節操作的 API 回應格式（`createSectionByInstructor`、`updateSection`、`publishSection`）
* 統一多個章節操作的 API 回應格式（`getCourseSectionsByInstructor`、`batchCreateSections`）
* 修改 `createSectionByInstructor` API，支援同時創建章節標題和內容
* 移除所有 API 回應中的 `order` 字段，改為使用 `orderIndex` 作為內部排序依據

---

### 詳細說明

1. API 回應格式統一化：
   - 單個章節操作 API 回應格式：
     ```json
     {
         "status": "success",
         "data": {
             "id": "uuid",
             "title": "章節標題",
             "content": "章節內容",
             "videoUrl": "影片URL",
             "isPublished": false
         }
     }
     ```
   - 多個章節操作 API 回應格式：
     ```json
     {
         "status": "success",
         "data": [
             {
                 "id": "uuid",
                 "title": "章節標題",
                 "content": "章節內容",
                 "videoUrl": "影片URL",
                 "isPublished": false
             }
         ]
     }
     ```

2. 章節創建功能優化：
   - 擴展 `createSectionByInstructor` API 的請求體格式：
     ```json
     {
         "title": "章節標題",
         "content": "章節內容"
     }
     ```
   - 使用 `sectionSchema` 進行請求體驗證
   - 同時保存標題和內容到資料庫

---

### 測試計畫

1. 測試章節創建 API：
 - 以postman做測試
 - 登入 -> 取得課程ID - > 新增章節
 
2. 測試章節更新 API：
 - 以postman做測試
 - 登入 -> 取得課程ID - > 新增章節  -> 更新章節

3. 測試章節發佈 API：
 - 以postman做測試
 - 登入 -> 取得課程ID - > 新增章節  -> 章節發佈

4. 測試獲取課程章節列表 API：
 - 以postman做測試
 - 登入 -> 取得課程ID - > 新增章節  -> 取得章節列表

5. Jest + superTest test case:
 - npm run test:api


**測試結果:**
- 所有 API 回應格式符合新的統一規範
- 章節創建 API 成功保存標題和內容
- 所有 API 的錯誤處理正常運作
- 資料庫中的章節資料結構正確

---

### 相關文件

* 更新了 API 文件中的章節相關 API 說明
* 更新了請求體和回應格式的範例

---

### 其他說明

* 本次修改不涉及資料庫結構變更
* 所有 API 的錯誤處理邏輯保持不變
* 章節排序邏輯保持不變，僅移除了回應中的 `order` 字段

---

### Checklist

* [x] 我已經閱讀並理解了專案的程式碼風格指南
* [x] 我的程式碼風格與專案的風格保持一致
* [x] 我已經為我的變更編寫了測試案例
* [x] 所有的測試都已通過
* [x] 我已經更新了相關的 API 文件
* [x] 我的提交資訊清晰明瞭


---

### 截圖 (如果適用)

如果你的變更涉及到 UI 方面的修改，請在此處附上截圖以便審閱。

---

**感謝你的貢獻!**