### PR TITLE
Feature/sections reorder

### DIFF
--- a/src/controllers/instructorSectionsController.ts
+++ b/src/controllers/instructorSectionsController.ts
@@ -567,6 +567,14 @@ export async function sortSections(req: AuthRequest, res: Response, next: NextFu
       return;
     }
 
+    //檢查ID是否重複
+    const inputSectionIds = sections.map((s) => s.id);
+    const uniqueInputIds = new Set(inputSectionIds);
+    if (uniqueInputIds.size !== sections.length) {
+      res.status(422).json({ status: "fail", message: "傳入的章節ID不能重複" });
+      return;
+    }
+
     // 檢查章節狀態
     const hasPublishedSection = allCourseSections.some((section) => section.isPublished);
     if (hasPublishedSection) {

--- a/src/routes/instructorRoutes.ts
+++ b/src/routes/instructorRoutes.ts
@@ -23,6 +23,7 @@ import {
   publishSection,
   generateCourseSections,
   batchCreateSections,
+  sortSections,
 } from "../controllers/instructorSectionsController";
 
 const router = Router();
@@ -63,6 +64,7 @@ router.delete("/coupons/:id", isAuth, isInstructor, deleteCoupon);
 
 router.get("/courses/:id/sections", isAuth, isInstructor, getCourseSectionsByInstructor);
 router.post("/courses/:id/sections", isAuth, isInstructor, createSectionByInstructor);
+router.put("/courses/:id/sections/sort", isAuth, isInstructor, sortSections);
 router.post("/courses/:id/sections/batch", isAuth, isInstructor, batchCreateSections);
 
 router.patch("/sections/:id", isAuth, isInstructor, updateSection);

--- a/src/test/testInstructorSectionController/sortSections.api.test.ts
+++ b/src/test/testInstructorSectionController/sortSections.api.test.ts
@@ -1,0 +1,232 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import request from "supertest";
+import app from "../../app";
+import { AppDataSource } from "../../config/db";
+import { createTestToken } from "../../utils/jwtUtils";
+
+jest.mock("../../config/db", () => ({
+  AppDataSource: {
+    getRepository: jest.fn(),
+    transaction: jest.fn().mockImplementation((callback) => callback({ update: jest.fn() })),
+  },
+}));
+
+const mockGetRepository = AppDataSource.getRepository as jest.Mock;
+
+const fakeUserId = "user-123";
+const fakeCourseId = "123e4567-e89b-12d3-a456-426614174999";
+const fakeToken = createTestToken({ id: fakeUserId, role: "instructor" });
+const studentToken = createTestToken({ id: fakeUserId, role: "student" });
+
+let sectionRepoMock: any;
+let courseRepoMock: any;
+
+function buildSectionRepoMock(overrides = {}) {
+  return {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  courseRepoMock = { findOne: jest.fn() };
+  sectionRepoMock = buildSectionRepoMock();
+
+  mockGetRepository.mockImplementation((entity) => {
+    if (entity.name === "Course") return courseRepoMock;
+    if (entity.name === "Section") return sectionRepoMock;
+  });
+});
+
+const baseURL = `/api/v1/instructor/courses/${fakeCourseId}/sections/sort`;
+
+describe("PUT /api/v1/instructor/courses/:courseId/sections/sort", () => {
+  const mockSections = [
+    { id: "section-1", order: 1 },
+    { id: "section-2", order: 2 },
+    { id: "section-3", order: 3 },
+  ];
+
+  const mockUpdatedSections = [
+    { id: "section-1", title: "第一章", content: "內容1", videoUrl: null, isPublished: false },
+    { id: "section-2", title: "第二章", content: "內容2", videoUrl: null, isPublished: false },
+    { id: "section-3", title: "第三章", content: "內容3", videoUrl: null, isPublished: false },
+  ];
+
+  // 🟢 正常流程
+  it("✅ 成功更新章節順序", async () => {
+    courseRepoMock.findOne.mockResolvedValue({
+      id: fakeCourseId,
+      instructorId: fakeUserId,
+      isPublished: false,
+      orders: [],
+    });
+
+    sectionRepoMock.find.mockResolvedValue(mockUpdatedSections);
+
+    const res = await request(app).put(baseURL).set("Authorization", `Bearer ${fakeToken}`).send({ sections: mockSections });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("success");
+    expect(res.body.data).toHaveLength(3);
+    expect(res.body.data[0]).toHaveProperty("id");
+    expect(res.body.data[0]).toHaveProperty("title");
+    expect(res.body.data[0]).toHaveProperty("content");
+    expect(res.body.data[0]).toHaveProperty("videoUrl");
+    expect(res.body.data[0]).toHaveProperty("isPublished");
+  });
+
+  // 🔐 身分驗證
+  it("❌ 未帶 JWT → 回傳 401", async () => {
+    const res = await request(app).put(baseURL).send({ sections: mockSections });
+    expect(res.status).toBe(401);
+  });
+
+  it("❌ 學生身分呼叫 → 回傳 403", async () => {
+    const res = await request(app).put(baseURL).set("Authorization", `Bearer ${studentToken}`).send({ sections: mockSections });
+
+    expect(res.status).toBe(403);
+  });
+
+  // ⚠ Zod 驗證
+  it("❌ 缺少 sections 欄位 → 回傳 400", async () => {
+    const res = await request(app).put(baseURL).set("Authorization", `Bearer ${fakeToken}`).send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it("❌ sections 不是陣列 → 回傳 400", async () => {
+    const res = await request(app).put(baseURL).set("Authorization", `Bearer ${fakeToken}`).send({ sections: "not-an-array" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("❌ sections 為空陣列 → 回傳 400", async () => {
+    const res = await request(app).put(baseURL).set("Authorization", `Bearer ${fakeToken}`).send({ sections: [] });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("❌ order 值重複 → 回傳 422", async () => {
+    courseRepoMock.findOne.mockResolvedValue({
+      id: fakeCourseId,
+      instructorId: fakeUserId,
+      isPublished: false,
+      orders: [],
+    });
+    sectionRepoMock.find.mockResolvedValue([
+      { id: "section-1", isPublished: false },
+      { id: "section-2", isPublished: false },
+    ]);
+    const res = await request(app)
+      .put(baseURL)
+      .set("Authorization", `Bearer ${fakeToken}`)
+      .send({
+        sections: [
+          { id: "section-1", order: 1 },
+          { id: "section-2", order: 1 },
+        ],
+      });
+    expect(res.status).toBe(422);
+  });
+
+  it("❌ order 值不從 1 開始 → 回傳 422", async () => {
+    courseRepoMock.findOne.mockResolvedValue({
+      id: fakeCourseId,
+      instructorId: fakeUserId,
+      isPublished: false,
+      orders: [],
+    });
+    sectionRepoMock.find.mockResolvedValue([
+      { id: "section-1", isPublished: false },
+      { id: "section-2", isPublished: false },
+    ]);
+    const res = await request(app)
+      .put(baseURL)
+      .set("Authorization", `Bearer ${fakeToken}`)
+      .send({
+        sections: [
+          { id: "section-1", order: 2 },
+          { id: "section-2", order: 3 },
+        ],
+      });
+    expect(res.status).toBe(422);
+  });
+
+  // 🔐 權限控制
+  it("❌ 不是自己的課程 → 回傳 403", async () => {
+    courseRepoMock.findOne.mockResolvedValue({
+      id: fakeCourseId,
+      instructorId: "other-instructor",
+    });
+
+    const res = await request(app).put(baseURL).set("Authorization", `Bearer ${fakeToken}`).send({ sections: mockSections });
+
+    expect(res.status).toBe(403);
+  });
+
+  // 🚫 狀態驗證
+  it("❌ 查無課程 → 回傳 404", async () => {
+    courseRepoMock.findOne.mockResolvedValue(null);
+
+    const res = await request(app).put(baseURL).set("Authorization", `Bearer ${fakeToken}`).send({ sections: mockSections });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("❌ 課程已發布且有學生購買 → 回傳 422", async () => {
+    courseRepoMock.findOne.mockResolvedValue({
+      id: fakeCourseId,
+      instructorId: fakeUserId,
+      isPublished: true,
+      orders: [{ paidAt: new Date() }],
+    });
+
+    const res = await request(app).put(baseURL).set("Authorization", `Bearer ${fakeToken}`).send({ sections: mockSections });
+
+    expect(res.status).toBe(422);
+  });
+
+  it("❌ 包含已發布的章節 → 回傳 422", async () => {
+    courseRepoMock.findOne.mockResolvedValue({
+      id: fakeCourseId,
+      instructorId: fakeUserId,
+      isPublished: false,
+      orders: [],
+    });
+
+    sectionRepoMock.find.mockResolvedValue([
+      { id: "section-1", isPublished: true },
+      { id: "section-2", isPublished: false },
+    ]);
+
+    const res = await request(app).put(baseURL).set("Authorization", `Bearer ${fakeToken}`).send({ sections: mockSections });
+
+    expect(res.status).toBe(422);
+  });
+
+  // 🧨 錯誤處理
+  it("❌ 資料庫查詢錯誤 → 回傳 500", async () => {
+    courseRepoMock.findOne.mockRejectedValue(new Error("DB Error"));
+
+    const res = await request(app).put(baseURL).set("Authorization", `Bearer ${fakeToken}`).send({ sections: mockSections });
+
+    expect(res.status).toBe(500);
+  });
+
+  it("❌ 資料庫更新錯誤 → 回傳 500", async () => {
+    courseRepoMock.findOne.mockResolvedValue({
+      id: fakeCourseId,
+      instructorId: fakeUserId,
+      isPublished: false,
+      orders: [],
+    });
+
+    (AppDataSource.transaction as jest.Mock).mockRejectedValueOnce(new Error("Transaction Error"));
+
+    const res = await request(app).put(baseURL).set("Authorization", `Bearer ${fakeToken}`).send({ sections: mockSections });
+
+    expect(res.status).toBe(500);
+  });
+}); 

--- a/src/validator/sectionVaildationsechema.ts
+++ b/src/validator/sectionVaildationsechema.ts
@@ -33,12 +33,10 @@ export const batchSectionSchema = z.object({
 });
 
 export const sectionInputSchema = z.object({
-  id: z.string().uuid(),
+  id: z.string().min(1, { message: "id 不可為空" }),
   order: z.number().int().min(1, { message: "order 必須為大於 0 的整數" }),
 });
 
 export const sortSectionsSchema = z.object({
-  body: z.object({
-    sections: z.array(sectionInputSchema).nonempty({ message: "sections 不可為空" }),
-  }),
+  sections: z.array(sectionInputSchema).nonempty({ message: "sections 不可為空" }),
 });

--- a/src/validator/sectionVaildationsechema.ts
+++ b/src/validator/sectionVaildationsechema.ts
@@ -31,3 +31,14 @@ export const aiSectionSchema = z.object({
 export const batchSectionSchema = z.object({
   sections: z.array(sectionSchema).min(1, "至少需要一個章節"),
 });
+
+export const sectionInputSchema = z.object({
+  id: z.string().uuid(),
+  order: z.number().int().min(1, { message: "order 必須為大於 0 的整數" }),
+});
+
+export const sortSectionsSchema = z.object({
+  body: z.object({
+    sections: z.array(sectionInputSchema).nonempty({ message: "sections 不可為空" }),
+  }),
+});


### PR DESCRIPTION
# Pull Request 概述

本次 PR 實現了課程章節排序功能，允許講師重新調整課程章節的順序。此功能對於課程內容的組織與管理非常重要，讓講師能夠根據教學需求靈活調整章節順序。

[排序章節紀錄API文件](https://www.notion.so/PUT-api-v1-instructor-courses-courseId-sections-sort-2046a24685188061841ec23dab608461?source=copy_link)

---

### 解決的問題

* 講師無法調整課程章節順序
* 章節順序調整時缺乏必要的驗證（例如：已發布課程、已購買課程等）
* 缺乏完整的 API 測試覆蓋

---

### 本次 PR 的主要變更

* 新增 PUT `/api/v1/instructor/courses/:courseId/sections/sort` API 端點
* 實作章節排序的業務邏輯，包含：
  * 課程權限驗證
  * 章節狀態驗證
  * 訂單狀態驗證
  * 排序值驗證
* 新增完整的 API 測試，覆蓋各種場景
* 優化錯誤處理與回傳訊息

---

### 詳細說明

#### 1. API 實作細節

* **請求格式**：
  ```json
  {
    "sections": [
      { "id": "section-1", "order": 1 },
      { "id": "section-2", "order": 2 }
    ]
  }
  ```

* **驗證邏輯**：
  * 課程必須存在且屬於當前講師
  * 課程未發布或已發布但無學生購買
  * 所有章節必須未發布
  * order 值必須從 1 開始且連續
  * order 值不可重複

* **回傳格式**：
  ```json
  {
    "status": "success",
    "message": "章節排序更新成功",
    "data": [
      {
        "id": "section-1",
        "title": "第一章",
        "content": "內容1",
        "videoUrl": null,
        "isPublished": false
      }
    ]
  }
  ```

#### 2. 測試覆蓋

新增 14 個測試案例，涵蓋：
* 正常流程（成功更新）
* 身分驗證（JWT、角色權限）
* 參數驗證（sections 格式、order 值）
* 權限控制（課程擁有權）
* 狀態驗證（課程狀態、章節狀態）
* 錯誤處理（資料庫錯誤）

---

### 測試計畫

1. **單元測試**
   ```bash
   npx jest src/test/testInstructorSectionController/sortSections.api.test.ts
   ```

2. **手動測試步驟**
   * 使用 Postman 或類似工具測試 API
   * 測試不同權限（講師、學生）
   * 測試各種錯誤情況（無效的 courseId、重複的 order 值等）
   * 驗證資料庫中的章節順序是否正確更新

**測試結果：**
* 所有 14 個測試案例均通過
* 手動測試確認功能正常運作
* 錯誤處理符合預期

---

### 相關文件

* 更新了 API 文件，新增章節排序 API 的說明
* 更新了 Postman 集合，新增章節排序 API 的測試案例

---

### 其他說明

* 本功能使用 Transaction 確保資料一致性
* 排序更新時會同時更新所有相關章節的 orderIndex
* 回傳資料不包含 orderIndex，避免前端混淆

---

### Checklist

* [x] 我已經閱讀並理解了專案的貢獻指南
* [x] 程式碼風格與專案保持一致
* [x] 已編寫完整的 API 測試
* [x] 所有測試都已通過
* [x] 已更新相關的 API 文件
* [x] 提交資訊清晰明瞭

---

### 後續優化建議

1. 考慮加入批次處理機制，處理大量章節排序的情況
2. 新增章節排序的歷史記錄功能
3. 優化資料庫查詢效能，特別是在處理大量章節時
