### PR TITLE
Feature/api 20 25 course playback group

### DIFF
--- a/src/controllers/courseController.ts
+++ b/src/controllers/courseController.ts
@@ -419,7 +419,7 @@ export async function markSectionComplete(req: AuthRequest, res: Response, next:
 /**
  * API #24 GET /api/v1/courses/:courseId/sections/:sectionId
  *
- * 📘 此 API 取得某章節影片與內容
+ * 📘 [API 文件 Notion 連結](https://www.notion.so/GET-api-v1-courses-courseId-sections-sectionId-1d06a246851880d0986dc604b538e99c?source=copy_link)
  *
  * 此 API 用於學生查看特定章節的詳細內容，包括影片和文字內容，
  * 同時會返回前後章節的資訊以便導航，以及學習進度

--- a/src/controllers/courseController.ts
+++ b/src/controllers/courseController.ts
@@ -553,7 +553,7 @@ export async function getSectionDetail(req: AuthRequest, res: Response, next: Ne
 }
 
 /**
- * API #20 GET /api/v1/courses/my-learning
+ * API #20 GET -/api/v1/courses/my-learning?page=1&pageSize=9
  *
  * 📘 [API 文件 Notion 連結](https://www.notion.so/GET-api-v1-courses-my-learning-page-1-pageSize-9-1d06a246851880d1b046fef844ac7cf3?source=copy_link)
  *

--- a/src/routes/courseRoutes.ts
+++ b/src/routes/courseRoutes.ts
@@ -6,6 +6,7 @@ import {
   getCourseProgress,
   markSectionComplete,
   getSectionDetail,
+  getMyLearningCourses,
 } from "../controllers/courseController";
 import { isAuth } from "../middleware/isAuth";
 import { isStudent } from "../middleware/isStudent";
@@ -13,6 +14,7 @@ import { isStudent } from "../middleware/isStudent";
 const router = Router();
 
 router.get("/", getCourses);
+router.get("/my-learning", isAuth, isStudent, getMyLearningCourses);
 router.get("/:courseId", getCourseDetail);
 router.get("/:courseId/sections", isAuth, isStudent, getCourseSections);
 router.get("/:courseId/progress", isAuth, isStudent, getCourseProgress);

--- a/src/routes/courseRoutes.ts
+++ b/src/routes/courseRoutes.ts
@@ -1,5 +1,12 @@
 import { Router } from "express";
-import { getCourses, getCourseDetail, getCourseSections, getCourseProgress, markSectionComplete } from "../controllers/courseController";
+import {
+  getCourses,
+  getCourseDetail,
+  getCourseSections,
+  getCourseProgress,
+  markSectionComplete,
+  getSectionDetail,
+} from "../controllers/courseController";
 import { isAuth } from "../middleware/isAuth";
 import { isStudent } from "../middleware/isStudent";
 
@@ -9,6 +16,7 @@ router.get("/", getCourses);
 router.get("/:courseId", getCourseDetail);
 router.get("/:courseId/sections", isAuth, isStudent, getCourseSections);
 router.get("/:courseId/progress", isAuth, isStudent, getCourseProgress);
+router.get("/:courseId/sections/:sectionId", isAuth, isStudent, getSectionDetail);
 router.patch("/:courseId/sections/:sectionId/complete", isAuth, isStudent, markSectionComplete);
 
 export default router;


### PR DESCRIPTION
# Pull Request 概述

本次 PR 新增了兩個學生學習相關的 API，提供學生查看章節詳細內容和學習課程清單的功能，完善了學習平台的核心功能。**同時修正了學習進度相關的重要問題。**

---

### 前情提要

https://drive.google.com/file/d/1e5KkAIK5pu2qJX_4vSAXjqzWwEwH1NYv/view?usp=sharing

### 測資 (方便測試用)

```
API #24

登入學生
arvinyang1925@gmail.com
CCdd1111

測試課程底下章節回傳 URL 範例

Javascript 進階開發 - 第二章：核心技術
{{baseUrl}}/api/v1/courses/fb23c072-5c6d-4bf6-9210-fd433eba0cab/sections/3b12e320-5a54-4b0f-9f47-166910b37473


男性coding持久力全解方 - 第二章：生理機制解析
{{baseUrl}}/api/v1/courses/71793237-aa39-4c77-aa9d-f0a55883e11f/sections/8d464255-cb8f-46a1-b0be-9e2781cff9bb


資料庫設計與優化 - 資料庫設計與優化_Chapter4
{{baseUrl}}/api/v1/courses/d5ad6d98-dec6-4aa7-9351-e9ef87e78385/sections/0c754d15-2f1e-497f-8349-a3facc6b9e23
```

---

### 本次 PR 的主要變更

請列出本次 PR 中引入的主要變更點，可以使用列表的形式：

* 新增 API 24 GET `/api/v1/courses/:courseId/sections/:sectionId` - 學生查看特定章節詳細內容
* 新增 API 20 GET `/api/v1/courses/my-learning` - 學生查看正在學習的課程清單
* **🆕 更新 API 25 PATCH `/api/v1/courses/:courseId/sections/:sectionId/complete` - 修正章節完成邏輯**
* 在 `courseController.ts` 中新增 `getSectionDetail` 函數
* 在 `courseController.ts` 中新增 `getMyLearningCourses` 函數
* **🆕 修正 `markSectionComplete` 函數，自動建立學習進度記錄**
* **🆕 修正進度計算邏輯，只計算已發布的章節**
* 更新 `courseRoutes.ts` 新增對應的路由設定
* 引入 `Order` entity 以查詢學生已購買的課程

---

### 詳細說明

**API 24 - 章節詳細內容查看：**
- 提供章節的完整資訊（標題、內容、影片網址等）
- 包含前後章節的導航資訊，方便學生在課程中進行導航
- 查詢並回傳學生對該章節的學習進度狀態
- 加入完整的參數驗證和錯誤處理機制

**API 20 - 學習課程清單：**
- 基於訂單記錄查詢學生已購買的課程（`order.status = 'paid'`）
- 計算每個課程的學習進度百分比
- 支援分頁功能，預設每頁顯示 10 筆資料
- 即使學生尚未開始學習（無 StudentProgress 記錄），已購買的課程也會顯示進度為 0%
- 包含課程基本資訊和講師資訊
- **🆕 修正進度計算：只計算已發布且未刪除的章節，避免講師下架章節後進度計算錯誤**

**🆕 API 25 - 章節完成標記（重要修正）：**
- **修正原有 bug：當學生首次完成章節時，系統會自動在 `student_progress` 表中建立新記錄**
- **包含完整的欄位：`user_id`、`course_id`、`section_id`、`is_completed = true`**
- **改善用戶體驗：學生不需要先進入章節才能標記完成，可直接完成任何章節**
- **修正 TypeScript 錯誤：使用正確的 TypeORM save 方法建立記錄**

---

### 🆕 重要修正說明

**1. 學習進度記錄自動建立**
```typescript
// 修正前：找不到進度記錄時回傳錯誤
if (!existingProgress) {
  res.status(404).json({
    status: "failed",
    message: "找不到進度記錄",
  });
  return;
}

// 修正後：自動建立進度記錄
if (!existingProgress) {
  const savedProgress = await AppDataSource.getRepository(StudentProgress).save({
    user: { id: userId },
    course: { id: courseId },
    section: { id: sectionId },
    isCompleted: true,
  });
  progressId = savedProgress.id;
}
```

**2. 進度計算只考慮已發布章節**
```typescript
// 修正前：計算所有已完成的章節（包括已下架的）
const completedSections = await AppDataSource.getRepository(StudentProgress)
  .createQueryBuilder("progress")
  .where("progress.user_id = :userId", { userId })
  .andWhere("progress.course_id = :courseId", { courseId })
  .andWhere("progress.is_completed = true")
  .getCount();

// 修正後：只計算已發布且未刪除的已完成章節
const completedSections = await AppDataSource.getRepository(StudentProgress)
  .createQueryBuilder("progress")
  .innerJoin("progress.section", "section")
  .where("progress.user_id = :userId", { userId })
  .andWhere("progress.course_id = :courseId", { courseId })
  .andWhere("progress.is_completed = true")
  .andWhere("section.is_published = true")
  .andWhere("section.deleted_at IS NULL")
  .getCount();
```

**影響範圍：**
- `getCourseProgress` 函數
- `getMyLearningCourses` 函數

---

### 測試計畫

請描述你為了驗證本次 PR 的變更所進行的測試，以及如何重現這些測試。

* 測試 API 24：使用有效的 courseId 和 sectionId 呼叫 API，驗證回傳的章節資訊是否完整
* 測試 API 24：驗證前後章節導航資訊是否正確
* 測試 API 24：驗證學習進度查詢功能
* 測試 API 20：呼叫 API 驗證能正確回傳學生已購買的課程清單
* 測試 API 20：驗證進度計算是否正確，包括 0% 進度的課程
* 測試 API 20：驗證分頁功能是否正常運作
* **🆕 測試 API 25：驗證首次完成章節時自動建立進度記錄**
* **🆕 測試進度計算：驗證講師下架章節後進度百分比是否正確更新**
* 測試錯誤處理：使用無效的參數測試各種錯誤情境

**測試結果:**

所有測試案例均通過，API 能正確回傳預期的資料格式，錯誤處理機制運作正常。**新增的進度記錄建立功能和修正的進度計算邏輯都運作正常。**

---

### 相關文件 (如果適用)

* 新增了 API 註解文件，包含詳細的功能說明和 Notion 連結
* 程式碼中包含完整的 TypeScript 型別註解

---

### 其他說明

* API 20 的邏輯調整：從原本只查詢有學習進度的課程，改為查詢所有已購買的課程，確保購買但尚未開始學習的課程也會顯示在清單中
* 兩個 API 都需要學生身份驗證（`isAuth` + `isStudent` 中間件）
* API 回傳格式遵循專案既有的統一格式規範
* **🆕 修正了學習進度系統的重要 bug，提升用戶體驗和資料準確性**
* **🆕 解決了講師下架章節後可能導致進度計算錯誤的問題**

---

### Checklist

在提交 PR 之前，請確保你已經完成以下檢查：

* [x] 我已經閱讀並理解了 [貢獻指南](CONTRIBUTING.md 或其他相關文件)。
* [x] 我的程式碼風格與專案的風格保持一致。
* [ ] 我已經為我的變更編寫了單元測試 (如果適用)。
* [x] 所有的測試都已通過。
* [x] 我已經更新了相關的文件 (如果適用)。
* [x] 我的提交資訊清晰明瞭。
* **🆕 [x] 我已經驗證了學習進度相關的修正功能**

---

### 截圖 (如果適用)

無 UI 變更，僅為後端 API 開發。

---

**感謝你!**