### PR TITLE
fix: 🐛 API No11 調整只回傳已發佈課程

### DIFF
--- a/src/controllers/courseController.ts
+++ b/src/controllers/courseController.ts
@@ -24,7 +24,8 @@ export async function getCourses(req: Request, res: Response, next: NextFunction
     const [courses, totalItems] = await AppDataSource.getRepository(Course).findAndCount({
       relations: ["instructor"],
       where: {
-        deleted_at: IsNull(), // 只撈取未刪除的課程
+        deleted_at: IsNull(), 
+        isPublished: true, // 只撈取未刪除且已發布的課程
       },
       skip,
       take: pageSize,


### PR DESCRIPTION
issue 92

# Pull Request 概述

修復API11 
課程列表僅需顯示已發布的課程

---

### 解決的問題 (如果適用)

#92 

---

### 本次 PR 的主要變更

請列出本次 PR 中引入的主要變更點，可以使用列表的形式：

*courseController : getCourses


---


### 測試計畫

請描述你為了驗證本次 PR 的變更所進行的測試，以及如何重現這些測試。

* POSTMan打 api 11
* 確認回傳課程都是已發布(目前資料庫狀態為20堂)
* ...

**測試結果:符合預期

請說明測試的結果是否符合預期。

---

### 相關文件 (如果適用)

如果本次 PR 的變更涉及到文件更新，請在此處說明。例如：

* 更新了 `README.md` 文件，增加了關於新功能的說明。
* 新增了 API 文件。

---

### 其他說明

任何其他你認為審閱者需要了解的資訊，都可以在此處說明。例如，某些尚未完成但會在後續 PR 中處理的部分，或者某些需要特別注意的地方。

---

### Checklist

在提交 PR 之前，請確保你已經完成以下檢查：

* [ ] 我已經閱讀並理解了 [貢獻指南](CONTRIBUTING.md 或其他相關文件)。
* [ ] 我的程式碼風格與專案的風格保持一致。
* [ ] 我已經為我的變更編寫了單元測試 (如果適用)。
* [ ] 所有的測試都已通過。
* [ ] 我已經更新了相關的文件 (如果適用)。
* [ ] 我的提交資訊清晰明瞭。

---

### 截圖 (如果適用)

如果你的變更涉及到 UI 方面的修改，請在此處附上截圖以便審閱。

---

**感謝你的貢獻!**