### PR TITLE
fix: 🐛 fix delete url path

### DIFF
--- a/src/controllers/instructorVideoController.ts
+++ b/src/controllers/instructorVideoController.ts
@@ -5,7 +5,7 @@ import { Order } from "../entities/Order";
 import { uuidSchema } from "../validator/commonValidationSchemas";
 import { AuthRequest } from "../middleware/isAuth";
 import { simpleQueue } from "../utils/simpleQueue";
-import { deleteHLSFolderFromFirebase } from "../utils/firebaseUtils";
+import { deleteVideoFromFirebase } from "../utils/firebaseUtils";
 import { handleVideoUploadTask } from "../services/videoTranscodeService";
 
 /**
@@ -289,7 +289,28 @@ export async function deleteSectionVideo(req: AuthRequest, res: Response, next: 
       }
     }
 
-    await deleteHLSFolderFromFirebase(section.id);
+    // 取得副檔名
+    let ext = "";
+    try {
+      const url = new URL(section.videoUrl);
+      const pathname = url.pathname;
+      const match = pathname.match(/video(\.[a-zA-Z0-9]+)$/);
+      ext = match ? match[1] : "";
+    } catch {
+      /* ignore */
+    }
+
+    if (ext) {
+      await deleteVideoFromFirebase(section.id, ext);
+    } else {
+      // fallback: 若無法判斷副檔名，仍嘗試刪除 mp4
+      try {
+        await deleteVideoFromFirebase(section.id, ".mp4");
+      } catch {
+        /* ignore */
+      }
+    }
+
     await AppDataSource.query("UPDATE sections SET video_url = NULL WHERE id = $1", [section.id]);
 
     res.status(200).json({

--- a/src/utils/firebaseUtils.ts
+++ b/src/utils/firebaseUtils.ts
@@ -96,3 +96,18 @@ export async function deleteHLSFolderFromFirebase(sectionId: string) {
   const deletePromises = files.map((file) => file.delete());
   await Promise.all(deletePromises);
 }
+
+/**
+ * 刪除指定 section 的單一影片
+ * @param sectionId 章節 ID
+ * @param ext 副檔名（包含 .）
+ */
+export async function deleteVideoFromFirebase(sectionId: string, ext: string) {
+  const filePath = `sections/${sectionId}/video${ext}`;
+  const file = bucket.file(filePath);
+  const [exists] = await file.exists();
+  if (!exists) {
+    throw new Error("找不到影片檔案");
+  }
+  await file.delete();
+}


### PR DESCRIPTION
# Pull Request 概述

修正講師刪除章節影片時，Firebase 路徑與副檔名判斷錯誤的問題，確保影片能正確刪除。

---

### 解決的問題 (如果適用)

根據 issue  #107  功能修正
---

### 本次 PR 的主要變更

* 新增 `deleteVideoFromFirebase` 方法，根據 sectionId 與副檔名刪除正確的影片路徑。
* `deleteSectionVideo` 會根據 `section.videoUrl` 解析副檔名，並呼叫正確的刪除方法。
* 若無法解析副檔名，會 fallback 嘗試刪除 mp4。
* 移除未使用的 HLS 刪除邏輯。
* 修正 linter 問題。

---

### 詳細說明

原本的影片刪除僅針對 HLS 目錄，未考慮新版影片上傳路徑（`sections/{sectionId}/video{ext}`）。本次修正會根據 `videoUrl` 解析副檔名，並刪除正確的檔案，確保所有格式的影片都能被正確移除。

---

### 測試計畫

* 上傳影片（副檔名不限 mp4），確認能正常取得影片網址。
* 刪除影片，確認 Firebase Storage 對應路徑的影片檔案被移除。
* 測試無法解析副檔名時，預設刪除 mp4 路徑。
* 測試章節無影片、權限不足、已公開或有觀看紀錄等情境，回傳正確錯誤訊息。

**測試結果:**

所有情境皆符合預期，影片能正確刪除，未出現異常。

---

### 相關文件 (如果適用)

無需文件更新。

---

### 其他說明

無。

---

### Checklist

* [x] 我已經閱讀並理解了 [貢獻指南](CONTRIBUTING.md 或其他相關文件)。
* [x] 我的程式碼風格與專案的風格保持一致。
* [x] 我已經為我的變更編寫了單元測試 (如果適用)。
* [x] 所有的測試都已通過。
* [x] 我已經更新了相關的文件 (如果適用)。
* [x] 我的提交資訊清晰明瞭。

---

### 截圖 (如果適用)

無 UI 變更。

---

**感謝你的審閱！**