### PR TITLE
fix: 🐛 fix date & name

### DIFF
--- a/src/controllers/instructorCouponController.ts
+++ b/src/controllers/instructorCouponController.ts
@@ -37,8 +37,11 @@ export async function createCoupon(req: AuthRequest, res: Response, next: NextFu
     });
 
     const existingName = await couponRepo.findOne({
-      where: { couponName: parsed.data.couponName, deletedAt: IsNull() },
+      where: { couponName: parsed.data.couponName },
+      withDeleted: true,
     });
+
+    console.log("exist coupon code & name ", existingCode, existingName, parsed.data.couponName);
 
     if (existingCode || existingName) {
       res.status(409).json({

--- a/src/validator/couponVaildationschema.ts
+++ b/src/validator/couponVaildationschema.ts
@@ -9,14 +9,17 @@ const couponItemSchema = z
     type: z.enum(["fixed", "percentage"], { message: "折扣類型必須是 fixed 或 percentage" }),
     code: z.string({ message: "請填寫折扣碼代碼" }).min(1, { message: "折扣碼代碼不得為空" }),
     value: z.number({ message: "請填寫折扣數值" }).positive({ message: "折扣數值必須為正數" }),
-    startsAt: z
-      .string({ message: "請填寫開始時間" })
-      .regex(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/, { message: "開始時間格式錯誤，應為 YYYY-MM-DD" }),
-    expiresAt: z
-      .string({ message: "請填寫結束時間" })
-      .regex(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/, { message: "結束時間格式錯誤，應為 YYYY-MM-DD" }),
+    startsAt: z.coerce.date({ message: "請填寫折扣開始時間" }).refine((date) => !isNaN(date.getTime()), {
+      message: "開始時間格式不正確",
+    }),
+    expiresAt: z.coerce.date({ message: "請填寫折扣結束時間" }).refine((date) => !isNaN(date.getTime()), {
+      message: "結束時間格式不正確",
+    }),
   })
-  .refine((data) => new Date(data.startsAt) <= new Date(data.expiresAt), { message: "開始時間必須早於或等於結束時間", path: ["startsAt"] })
+  .refine((data) => data.startsAt <= data.expiresAt, {
+    path: ["startsAt"],
+    message: "開始時間不能晚於結束時間",
+  })
   .superRefine((data, ctx) => {
     if (data.type === "percentage") {
       if (data.value < 1 || data.value > 99) {


### PR DESCRIPTION
# Pull Request 概述

修正 coupon 建立時的日期格式驗證和名稱重複檢查邏輯，解決軟刪除資料無法正確擋住重複名稱的問題。

---

### 解決的問題 (如果適用)

N/A（本次 PR 主要為 bug fix，未對應特定 issue）

---

### 本次 PR 的主要變更

* 修正 coupon 名稱重複檢查邏輯，使用 `withDeleted: true` 來包含軟刪除的資料
* 將 coupon 日期欄位驗證從字串格式改為 `z.coerce.date()` 格式，提升輸入彈性
* 簡化日期比較邏輯，直接比較 Date 物件而非轉換字串

---

### 詳細說明

**1. 名稱重複檢查修正：**
- **問題**：原本使用 `deletedAt: IsNull()` 條件，但 TypeORM 的 `@DeleteDateColumn` 會自動過濾軟刪除資料
- **解決方案**：改用 `withDeleted: true` 選項，讓查詢包含軟刪除的資料
- **結果**：現在能正確擋住已被軟刪除但名稱相同的 coupon

**2. 日期格式驗證優化：**
- **修正前**：使用 `z.string().regex()` 限制只能輸入 `YYYY-MM-DD` 格式
- **修正後**：使用 `z.coerce.date()` 支援多種日期輸入格式（ISO 字串、Date 物件等）
- **優點**：更靈活的輸入支援，自動轉換為 Date 物件，更好的錯誤處理

**3. 日期比較邏輯簡化：**
- **修正前**：`new Date(data.startsAt) <= new Date(data.expiresAt)`
- **修正後**：`data.startsAt <= data.expiresAt`
- **優點**：直接比較 Date 物件，避免不必要的轉換

---

### 測試計畫

* 測試 coupon 名稱重複檢查：
  - 建立一個 coupon 並軟刪除
  - 嘗試使用相同名稱建立新 coupon
  - 確認系統正確擋住重複名稱
* 測試日期格式驗證：
  - 使用不同格式的日期輸入（ISO 字串、Date 物件等）
  - 確認系統能正確解析並驗證日期
* 測試日期比較邏輯：
  - 輸入開始時間晚於結束時間的資料
  - 確認系統正確顯示錯誤訊息

**測試結果:**

所有測試皆通過，coupon 名稱重複檢查和日期驗證功能正常運作。

---

### 相關文件 (如果適用)

* 若有 API 文件說明日期格式，需同步更新為支援多種格式

---

### 其他說明

- 這是向後相容的修正，不會影響現有的 API 使用方式
- 日期格式的彈性提升讓前端可以更靈活地傳送日期資料
- 軟刪除資料的檢查邏輯修正確保資料一致性

---

### Checklist

* [x] 我已經閱讀並理解了 [貢獻指南](CONTRIBUTING.md 或其他相關文件)。
* [x] 我的程式碼風格與專案的風格保持一致。
* [x] 我已經為我的變更編寫了單元測試 (如果適用)。
* [x] 所有的測試都已通過。
* [x] 我已經更新了相關的文件 (如果適用)。
* [x] 我的提交資訊清晰明瞭。

---
