### PR TITLE
fix: 🐛 add prompt to set percentage range

### DIFF
--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -67,6 +67,8 @@ ${keywordThemes || "無"}
 折扣類型：
 ${discountType}
 
+【重要】若 type 為 percentage，value 必須介於 1~99 之間。
+
 請輸出 JSON，格式如下：
 {
   "strategySummary": "摘要說明",

--- a/src/services/openAIService.ts
+++ b/src/services/openAIService.ts
@@ -61,6 +61,8 @@ ${launchDate}
 折扣型態：
 ${discountType}（fixed 表示固定金額；percentage 表示百分比）
 
+【重要】若 type 為 percentage，value 必須介於 1~99 之間。
+
 每段促銷期持續天數：
 ${phaseDurationDays} 天
 


### PR DESCRIPTION
# Pull Request 概述

調整 AI 產生促銷折扣碼時的參數說明，明確規範當 type 為 percentage 時，value 必須介於 1~99 之間，確保 AI 回傳的資料更符合業務邏輯需求。

---

### 解決的問題 (如果適用)

N/A（本次 PR 主要為 AI 產生折扣碼規則優化，未對應特定 issue）

---

### 本次 PR 的主要變更

* 調整 `generateCouponsPlanWithGemini` 的 prompt，加入「若 type 為 percentage，value 必須介於 1~99 之間」的明確說明
* 調整 `generateCouponsPlanWithOpenAI` 的 prompt，加入同樣的規則說明

---

### 詳細說明

- 針對 AI 產生促銷折扣碼的功能，無論是 Gemini 或 OpenAI，皆在 prompt 中加入：
  > 【重要】若 type 為 percentage，value 必須介於 1~99 之間。
- 這樣可確保 AI 回傳的 percentage 折扣值不會出現 0、100 或超過 100 的異常數值，減少後端驗證錯誤與資料不一致的情況。

---

### 測試計畫

* 呼叫 AI 產生促銷折扣碼的 API，觀察回傳的 percentage 類型 value 是否都在 1~99 之間
* 嘗試多次產生，確認 AI 不會產生超出區間的數值
* 若有後端驗證，確認不會再因為 AI 回傳異常數值而報錯

**測試結果:**

AI 回傳的 percentage 折扣值皆符合 1~99 的規範，測試通過。

---

### 相關文件 (如果適用)

* 若有 API 文件描述 AI 產生折扣碼的規則，請同步更新規則說明

---

### 其他說明

- 此調整僅影響 AI 產生折扣碼的規則說明，不影響現有 API 介面
- 若未來有更多折扣型態規則，可依此方式擴充

---

### Checklist

* [x] 我已經閱讀並理解了 [貢獻指南](CONTRIBUTING.md 或其他相關文件)。
* [x] 我的程式碼風格與專案的風格保持一致。
* [x] 我已經為我的變更編寫了單元測試 (如果適用)。
* [x] 所有的測試都已通過。
* [x] 我已經更新了相關的文件 (如果適用)。
* [x] 我的提交資訊清晰明瞭。

---

### 截圖 (如果適用)

N/A

---

**感謝你的貢獻!**